### PR TITLE
Fixes an ExecutionEngineException on Unity3D iOS.

### DIFF
--- a/LibTessDotNet/Sources/Geom.cs
+++ b/LibTessDotNet/Sources/Geom.cs
@@ -198,9 +198,9 @@ namespace LibTessDotNet
                     : (y + (x-y) * (b/(a+b))));
         }
 
-        static void Swap<T>(ref T a, ref T b)
+        static void Swap(ref MeshUtils.Vertex a, ref MeshUtils.Vertex b)
         {
-            T tmp = a;
+            var tmp = a;
             a = b;
             b = tmp;
         }

--- a/LibTessDotNet/Sources/PriorityQueue.cs
+++ b/LibTessDotNet/Sources/PriorityQueue.cs
@@ -65,9 +65,10 @@ namespace LibTessDotNet
         {
             internal int p, r;
         };
-        void Swap<T>(ref T a, ref T b)
+
+        static void Swap(ref int a, ref int b)
         {
-            T tmp = a;
+            int tmp = a;
             a = b;
             b = tmp;
         }


### PR DESCRIPTION
Hi,

I was having an ExecutionEngineException on Unity3D iOS for attempting to JIT compile the Swap method while running with AOT compilation. Since you're only using it with ints, making it non-generic fixes this. I think the fix is non-invasive enough that you might consider it. Another option is simply inlining the method manually.

Other than that, the library is working great, on all of Windows/Mac/iOS/Android.

Thanks,
Nuno
