### PR TITLE
Fixed bug in OutputContours.

### DIFF
--- a/LibTessDotNet/Sources/Tess.cs
+++ b/LibTessDotNet/Sources/Tess.cs
@@ -567,8 +567,9 @@ namespace LibTessDotNet
                 vertCount = 0;
                 start = edge = f._anEdge;
                 do {
-                    _vertices[vertIndex++].Position = edge._Org._coords;
-                    _vertices[vertIndex++].Data = edge._Org._data;
+                    _vertices[vertIndex].Position = edge._Org._coords;
+                    _vertices[vertIndex].Data = edge._Org._data;
+                    ++vertIndex;
                     ++vertCount;
                     edge = edge._Lnext;
                 } while (edge != start);


### PR DESCRIPTION
This seems to be a bug. When using ElementType.BoundaryContours the bug lead to crashes every time. This seems to fix it.

I've isolated this one into a branch so you can merge it more easily, but my master branch has a handful more changes which might be interesting nevertheless.

Thanks!
