### PR TITLE
Small change to avoid level 4 compiler warning.

### DIFF
--- a/LibTessDotNet/Sources/Tess.cs
+++ b/LibTessDotNet/Sources/Tess.cs
@@ -315,8 +315,8 @@ namespace LibTessDotNet
             var up = face._anEdge;
             Debug.Assert(up._Lnext != up && up._Lnext._Lnext != up);
 
-            for (; Geom.VertLeq(up._Dst, up._Org); up = up._Lprev) { }
-            for (; Geom.VertLeq(up._Org, up._Dst); up = up._Lnext) { }
+            while (Geom.VertLeq(up._Dst, up._Org)) up = up._Lprev;
+            while (Geom.VertLeq(up._Org, up._Dst)) up = up._Lnext;
 
             var lo = up._Lprev;
 

--- a/LibTessDotNet/Sources/Tess.cs
+++ b/LibTessDotNet/Sources/Tess.cs
@@ -315,8 +315,8 @@ namespace LibTessDotNet
             var up = face._anEdge;
             Debug.Assert(up._Lnext != up && up._Lnext._Lnext != up);
 
-            for (; Geom.VertLeq(up._Dst, up._Org); up = up._Lprev);
-            for (; Geom.VertLeq(up._Org, up._Dst); up = up._Lnext);
+            for (; Geom.VertLeq(up._Dst, up._Org); up = up._Lprev) { }
+            for (; Geom.VertLeq(up._Org, up._Dst); up = up._Lnext) { }
 
             var lo = up._Lprev;
 


### PR DESCRIPTION
Firstly!!!! Thanks for your awesome work on this project.
Secondly... just my minuscule "no net change" contribution to get rid of a compiler warning I get when building under Unity, which seems to enable level 4 compiler warnings by default.