### PR TITLE
Removed JIT dependency

### DIFF
--- a/LibTessDotNet/Sources/MeshUtils.cs
+++ b/LibTessDotNet/Sources/MeshUtils.cs
@@ -127,8 +127,6 @@ namespace LibTessDotNet
     {
         private Queue<T> _pool = new Queue<T>();
 
-        private static readonly Func<T> Creator = Expression.Lambda<Func<T>>(Expression.New(typeof(T))).Compile();
-
         public object Get()
         {
             lock (_pool)
@@ -138,7 +136,7 @@ namespace LibTessDotNet
                     return _pool.Dequeue();
                 }
             }
-            return Creator();
+            return new T();
         }
 
         public void Return(object obj)


### PR DESCRIPTION
Creator war compiling at runtime to generate a Lambda that instantiate an object of type T.
Replaced with new T()

Discussed in issue #51 